### PR TITLE
Constant was removed in the current version

### DIFF
--- a/contracts/Todos.sol
+++ b/contracts/Todos.sol
@@ -8,7 +8,7 @@ contract Todos {
         todos.push(todo);
     }
 
-    function getTodos() constant public returns (bytes32[]) {
+    function getTodos() view public returns (bytes32[]) {
         return todos;
     }
 }


### PR DESCRIPTION
The state mutability modifier "constant" was removed in version 0.5.0. Use "view" or "pure" instead. See the stack overflow discussion below:
https://ethereum.stackexchange.com/questions/28898/when-to-use-view-and-pure-in-place-of-constant