### PR TITLE
Constructors should have the keyword Constructor

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -8,7 +8,7 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  function Migrations() public {
+  constructor() public {
     owner = msg.sender;
   }
 


### PR DESCRIPTION
Functions are not allowed to have the same name as the contract. If you intend this to be a constructor, use "constructor(...) { ... }" to define it.